### PR TITLE
Migrate from stdout to GITHUB_OUTPUT

### DIFF
--- a/main.go
+++ b/main.go
@@ -430,7 +430,7 @@ func release(source string, destination string, output string, cnOutput string, 
 	if err != nil {
 		return err
 	}
-	setActionOutput("tag", *sourceRelease.Name)
+	setActionOutput("tag", *sourceRelease.TagName)
 	return nil
 }
 


### PR DESCRIPTION
# Description
This PR introduces the following improvements to our GitHub Actions workflow:

1. Replaces the deprecated stdout-based set-output method with the new GITHUB_OUTPUT environment variable.
2. Use tag from *sourceRelease.TagName instead of *sourceRelease.Name to set release tag.