### PR TITLE
Avoid merging category-companies@cn into geolocation-cn

### DIFF
--- a/main.go
+++ b/main.go
@@ -246,6 +246,13 @@ func mergeTags(data map[string][]geosite.Item) {
 		codeList = append(codeList, code)
 	}
 	var cnCodeList []string
+	// Company-wide @cn buckets may contain domains that are still unsuitable for
+	// a generic mainland-direct list. For example, category-companies@cn pulls in
+	// google@cn entries such as ssl.gstatic.com and fonts.googleapis.com, which
+	// makes geolocation-cn too broad for common direct-routing use.
+	geolocationCNMergeExclusions := map[string]bool{
+		"category-companies@cn": true,
+	}
 	for _, code := range codeList {
 		codeParts := strings.Split(code, "@")
 		if len(codeParts) != 2 {
@@ -258,6 +265,9 @@ func mergeTags(data map[string][]geosite.Item) {
 			continue
 		}
 		if strings.HasSuffix(codeParts[0], "-cn") || strings.HasSuffix(codeParts[0], "-!cn") {
+			continue
+		}
+		if geolocationCNMergeExclusions[code] {
 			continue
 		}
 		cnCodeList = append(cnCodeList, code)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sagernet/sing-box/common/geosite"
+)
+
+func hasItem(items []geosite.Item, want geosite.Item) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMergeTagsSkipsCategoryCompaniesAtCN(t *testing.T) {
+	companyItem := geosite.Item{Type: geosite.RuleTypeDomain, Value: "ssl.gstatic.com"}
+	devItem := geosite.Item{Type: geosite.RuleTypeDomain, Value: "pkg.go.dev"}
+	baseItem := geosite.Item{Type: geosite.RuleTypeDomain, Value: "example.cn"}
+
+	data := map[string][]geosite.Item{
+		"geolocation-cn":        {baseItem},
+		"category-companies@cn": {companyItem},
+		"category-dev@cn":       {devItem},
+	}
+
+	mergeTags(data)
+
+	got := data["geolocation-cn"]
+	if !hasItem(got, baseItem) {
+		t.Fatalf("base geolocation-cn item missing after merge")
+	}
+	if !hasItem(got, devItem) {
+		t.Fatalf("expected category-dev@cn item to still merge into geolocation-cn")
+	}
+	if hasItem(got, companyItem) {
+		t.Fatalf("did not expect category-companies@cn item to merge into geolocation-cn")
+	}
+}


### PR DESCRIPTION
## Summary
- exclude `category-companies@cn` from the extra `geolocation-cn` merge in `mergeTags()`
- add a focused test covering the exclusion while keeping other `category-*@cn` merges intact

## Why
`v2fly/domain-list-community` raw `geolocation-cn` does not include `google`, but `category-companies` includes `google`, and `google@cn` contains domains such as `ssl.gstatic.com`, `www.gstatic.com`, and `fonts.googleapis.com`.

When `category-companies@cn` is merged into `geolocation-cn`, the generated rule-set becomes too broad for common mainland direct-routing usage and may classify blocked Google service domains as direct-connect targets.

This change keeps the existing merge behavior for the other category-based `@cn` buckets, while preventing the `category-companies@cn` expansion from pulling mixed-accessibility company domains into `geolocation-cn`.

## Test plan
- run `go test ./...`

Made with [Cursor](https://cursor.com)